### PR TITLE
Use a function to get deviceID rather than relying on the initialize …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,12 +28,10 @@ import {
 } from './storage';
 
 import {
-  CACHE_LOCATION_MEMORY,
   DEFAULT_SESSION_CHECK_EXPIRY_DAYS,
   DEFAULT_SLASHAUTH_CLIENT,
   DEFAULT_NOW_PROVIDER,
   DEFAULT_FETCH_TIMEOUT_MS,
-  RECOVERABLE_ERRORS,
   CACHE_LOCATION_LOCAL_STORAGE,
 } from './constants';
 
@@ -61,7 +59,7 @@ import {
 // eslint-disable-next-line import/default
 // import TokenWorker from './worker/token.worker.ts';
 import { CacheKeyManifest } from './cache/key-manifest';
-import browserDeviceID from './device';
+import getDeviceID from './device';
 import {
   getNonceToSign,
   loginWithSignedNonce,
@@ -570,7 +568,7 @@ export default class SlashAuthClient {
         const authResult = await this._getTokenUsingRefreshToken({
           audience: getTokenOptions.audience || 'default',
           baseUrl: getDomain(this.domainUrl),
-          device_id: browserDeviceID,
+          device_id: getDeviceID(),
         });
 
         await this.cacheManager.set({
@@ -692,7 +690,7 @@ export default class SlashAuthClient {
   public async getNonceToSign(options: GetNonceToSignOptions): Promise<string> {
     const queryParameters = {
       address: options.address,
-      device_id: browserDeviceID,
+      device_id: getDeviceID(),
       client_id: this.options.clientID,
     };
 
@@ -733,7 +731,7 @@ export default class SlashAuthClient {
     const queryParameters = {
       address: options.address,
       signature: options.signature,
-      device_id: browserDeviceID,
+      device_id: getDeviceID(),
       client_id: this.options.clientID,
     };
 
@@ -828,7 +826,7 @@ export default class SlashAuthClient {
     }
 
     if (!options.device_id) {
-      options.device_id = browserDeviceID;
+      options.device_id = getDeviceID();
     }
 
     const { ...logoutOptions } = options;
@@ -908,7 +906,7 @@ export default class SlashAuthClient {
 
     const queryParameters = {
       refresh_token: cache.refresh_token,
-      device_id: browserDeviceID,
+      device_id: getDeviceID(),
     };
 
     const tokenResult = await refreshToken({

--- a/src/device.ts
+++ b/src/device.ts
@@ -1,33 +1,35 @@
 import { ICache, InMemoryCache, LocalStorageCache } from './cache';
 import { createRandomString } from './utils/string';
 
-let cache: ICache;
-if (typeof window !== 'undefined') {
-  if (typeof window.localStorage !== 'undefined') {
-    cache = new LocalStorageCache();
+const getDeviceID = () => {
+  let cache: ICache;
+  if (typeof window !== 'undefined') {
+    if (typeof window.localStorage !== 'undefined') {
+      cache = new LocalStorageCache();
+    }
   }
-}
-if (!cache) {
-  cache = new InMemoryCache().enclosedCache;
-}
-
-const DEVICE_ID = '_slashauth-browser-id';
-
-let browserDeviceID = createRandomString(24);
-let success = false;
-
-try {
-  const existing = cache.get<string>(DEVICE_ID) as string;
-  if (existing) {
-    browserDeviceID = existing;
-    success = true;
+  if (!cache) {
+    cache = new InMemoryCache().enclosedCache;
   }
-  // eslint-disable-next-line no-empty
-} catch {}
 
-if (!success) {
-  const browserDeviceID = createRandomString(24);
-  cache.set<string>(DEVICE_ID, browserDeviceID);
-}
+  const DEVICE_ID = '_slashauth-browser-id';
 
-export default browserDeviceID;
+  let browserDeviceID = createRandomString(24);
+  let success = false;
+
+  try {
+    const existing = cache.get<string>(DEVICE_ID) as string;
+    if (existing) {
+      browserDeviceID = existing;
+      success = true;
+    }
+    // eslint-disable-next-line no-empty
+  } catch {}
+
+  if (!success) {
+    cache.set<string>(DEVICE_ID, browserDeviceID);
+  }
+  return browserDeviceID;
+};
+
+export default getDeviceID;

--- a/src/provider/index.tsx
+++ b/src/provider/index.tsx
@@ -8,7 +8,6 @@ import React, {
 import SlashAuthContext, { SlashAuthContextInterface } from '../auth-context';
 import { initialAuthState } from '../auth-state';
 import SlashAuthClient from '../client';
-import { ICache } from '../cache';
 import {
   CacheLocation,
   GetIdTokenClaimsOptions,
@@ -144,14 +143,8 @@ const Provider = (opts: SlashAuthProviderOptions): JSX.Element => {
   );
   const [state, dispatch] = useReducer(reducer, initialAuthState);
 
-  const {
-    account,
-    library,
-    connectOnStart,
-    connectWallet,
-    provider,
-    deactivate,
-  } = useWalletAuth(opts.providers);
+  const { account, library, connectWallet, provider, deactivate } =
+    useWalletAuth(opts.providers);
 
   useEffect(() => {
     connectWallet(true).then(() => checkSession());


### PR DESCRIPTION
…flow.

This is causing some weird interactions in certain client apps.
Explicitly fetching the deviceID should keep it consistent.