### PR TITLE
add default connectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ straightforward as possible.
 
 ### Fixed
 
+## [0.11.3] - 2020-11-9
+
+### Added
+
+### Changed
+
+### Fixed
+- Set default connectors when a user passes in a wagmiClient with no connectors.
+
 ## [0.11.0] - 2020-10-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.11.2-beta.2",
+  "version": "0.11.3",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.11.2-beta.1",
+  "version": "0.11.2-beta.2",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.11.1",
+  "version": "0.11.2-beta.1",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/web3/manager.ts
+++ b/src/core/web3/manager.ts
@@ -254,7 +254,15 @@ export class Web3Manager {
         );
       }
       this.#client = this.#config.wagmiOptions.wagmiClient as WagmiClient;
-      this.#connectors = this.#client.connectors;
+
+      // Show our four default connectors if only an injected connector is passed in
+      // (this is wagmi's default when no connectors are passed into the wagmi client)
+      if (
+        this.#client.connectors.length !== 1 ||
+        this.#client.connectors[0].id !== 'injected'
+      ) {
+        this.#connectors = this.#client.connectors;
+      }
     } else {
       this.#client = createClient({
         autoConnect,

--- a/src/core/web3/manager.ts
+++ b/src/core/web3/manager.ts
@@ -258,8 +258,9 @@ export class Web3Manager {
       // Show our four default connectors if only an injected connector is passed in
       // (this is wagmi's default when no connectors are passed into the wagmi client)
       if (
-        this.#client.connectors.length !== 1 ||
-        this.#client.connectors[0].id !== 'injected'
+        this.#client.connectors.length !== 0 &&
+        (this.#client.connectors.length !== 1 ||
+          this.#client.connectors[0].id !== 'injected')
       ) {
         this.#connectors = this.#client.connectors;
       }


### PR DESCRIPTION
## Refs

## What?
Users who pass in their own wagmiClient without any `connectors` are only shown the `injectedProvider`. This update shows our four default options (if enabled) if a wagmiClient is passed in with no connectors.

## Why?
Customer need