### PR TITLE
Update docs and tests by replacing loginNoRedirectNoPopup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ straightforward as possible.
 
 ### Changed
 
+- Updated README by replacing `loginNoRedirectNoPopup` with `openSignIn`
+- Updated tests by replacing `loginNoRedirectNoPopup` with `openSignIn`
+
 ### Fixed
 
 ## [0.11.3] - 2020-11-9
@@ -28,6 +31,7 @@ straightforward as possible.
 ### Changed
 
 ### Fixed
+
 - Set default connectors when a user passes in a wagmiClient with no connectors.
 
 ## [0.11.0] - 2020-10-24

--- a/README.md
+++ b/README.md
@@ -96,17 +96,17 @@ Congratulations! Your app is now connected to /auth.
 
 ### Add login with wallet
 
-The /auth SDK gives you tools to quickly implement authentication via Metamask wallet in your React application. The simplest implementation is to log the user in directly in their browser. We use the function loginNoRedirectNoPopup() from the useSlashAuth() hook to accomplish this.
+The /auth SDK gives you tools to quickly implement authentication via Metamask wallet in your React application. The simplest implementation is to log the user in directly in their browser. We use the function openSignIn() from the useSlashAuth() hook to accomplish this.
 
 ```tsx
 // file:LoginButton.tsx
 import { useSlashAuth } from '@slashauth/slashauth-react';
 
 export const LoginButton = () => {
-  const { loginNoRedirectNoPopup } = useSlashAuth();
+  const { openSignIn } = useSlashAuth();
 
   return (
-    <button className="login-button" onClick={() => loginNoRedirectNoPopup()}>
+    <button className="login-button" onClick={() => openSignIn()}>
       Login With Wallet
     </button>
   );

--- a/src/core/context/legacy-slashauth.tsx
+++ b/src/core/context/legacy-slashauth.tsx
@@ -261,7 +261,6 @@ const emptyContext = {
   hasOrgRole: uninitializedStub,
   getRoleMetadata: uninitializedStub,
   getTokens: uninitializedStub,
-  loginNoRedirectNoPopup: uninitializedStub,
   openSignIn: uninitializedStub,
   logout: uninitializedStub,
   getIdTokenClaims: uninitializedStub,

--- a/tests/src/App.tsx
+++ b/tests/src/App.tsx
@@ -110,7 +110,7 @@ function App() {
     initialized,
     isAuthenticated,
     logout,
-    loginNoRedirectNoPopup,
+    openSignIn,
     connect,
     mountDropDown,
   } = context;
@@ -148,7 +148,7 @@ function App() {
         {!isAuthenticated && (
           <button
             onClick={() => {
-              loginNoRedirectNoPopup();
+              openSignIn();
             }}
           >
             Open sign in


### PR DESCRIPTION
## What?

Replace `loginNoRedirectNoPopup` usage with `openSignIn`

## Why?

Because in v0.11 `loginNoRedirectNoPopup` was removed and we don't want to confuse our customers

## Screenshots: 

![image](https://user-images.githubusercontent.com/17853818/211393472-d42467db-dc8b-4252-8752-c3d39e60345a.png)
