### PR TITLE
SLA-1925 Create base button and button with icon components (WIP)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.14.0",
+  "version": "1.0.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "0.14.0",
+      "version": "1.0.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "0.14.0",
+  "version": "1.0.0-beta.0",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/primitives/button.module.css
+++ b/src/core/ui/components/primitives/button.module.css
@@ -1,0 +1,36 @@
+.baseButton {
+  display: inline-block;
+  margin: auto;
+  padding: 8px 20px;
+  border-radius: var(--slashauth-borderRadius, 22px);
+
+  color: var(--slashauth-fontColor, #363849);
+  font-family: var(--slashauth-fontFamily, sans-serif);
+  line-height: 17px;
+  font-size: 14px;
+  font-weight: 500;
+
+  background: var(--slashauth-buttonBackgroundColor);
+  border: solid 1px var(--slashauth-lineColor, #E5E7EB);
+
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.baseButton:hover {
+  background: var(--slashauth-hoverButtonBackgroundColor);
+}
+
+.primaryButton {
+  border-color: var(--slashauth-primaryButtonBackgroundColor, #424559);
+  background-color: var(--slashauth-primaryButtonBackgroundColor, #424559);
+  color: var(--slashauth-primaryButtonTextColor, white);
+}
+
+.primaryButton:hover {
+  color: var(--slashauth-primaryButtonBackgroundColor, #424559);
+}
+
+.wide {
+  width: 100%;
+}

--- a/src/core/ui/components/primitives/button.tsx
+++ b/src/core/ui/components/primitives/button.tsx
@@ -1,5 +1,9 @@
 import { useState } from 'react';
 import { useAppearance } from '../../context/appearance';
+import { classNames } from '../../../../shared/utils/classnames';
+import { HighlightedIcon } from './icon';
+import { Flex } from './container';
+import styles from './button.module.css';
 
 type Props = {
   children: React.ReactNode;
@@ -71,3 +75,40 @@ export const SecondaryButton = ({ children, onClick }: Props) => {
     </button>
   );
 };
+
+interface BaseButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  padding?: number;
+  wide?: boolean;
+  primary?: boolean;
+  children: React.ReactNode;
+}
+
+export const BaseButton = ({
+  padding,
+  wide,
+  primary,
+  children,
+  ...props
+}: BaseButtonProps) => (
+  <button
+    {...props}
+    style={{ padding: padding }}
+    className={classNames(
+      styles.baseButton,
+      wide && styles.wide,
+      primary && styles.primaryButton
+    )}
+  >
+    {children}
+  </button>
+);
+
+export const ButtonWithIcon = ({ icon, children }) => (
+  <BaseButton wide padding={12}>
+    <Flex gap={17} alignItems="center">
+      <HighlightedIcon>{icon}</HighlightedIcon>
+      {children}
+    </Flex>
+  </BaseButton>
+);

--- a/src/core/ui/components/primitives/container.tsx
+++ b/src/core/ui/components/primitives/container.tsx
@@ -1,0 +1,3 @@
+export const Flex = ({ gap, children, alignItems }) => (
+  <span style={{ display: 'flex', gap, alignItems }}>{children}</span>
+);

--- a/src/core/ui/components/primitives/icon.module.css
+++ b/src/core/ui/components/primitives/icon.module.css
@@ -1,0 +1,13 @@
+.highlightedIcon {
+  box-sizing: border-box;
+  display: inline-block;
+  height: 48px;
+  width: 48px;
+  border: 1px solid var(--slashauth-lineColor, #E5E7EB);
+  border-radius: calc(var(--slashauth-borderRadius, 22px) * 0.6);
+  padding: 8px;
+}
+
+.highlightedIcon img {
+  width: 30px;
+}

--- a/src/core/ui/components/primitives/icon.tsx
+++ b/src/core/ui/components/primitives/icon.tsx
@@ -1,0 +1,5 @@
+import styles from './icon.module.css';
+
+export const HighlightedIcon = ({ children }) => (
+  <span className={styles.highlightedIcon}>{children}</span>
+);

--- a/src/core/ui/context/appearance.tsx
+++ b/src/core/ui/context/appearance.tsx
@@ -12,7 +12,7 @@ const DEFAULT_MODAL_STYLES: ComputedSlashAuthModalStyle = {
   backgroundColor: '#ffffff',
   buttonBackgroundColor: '#ffffff',
   hoverButtonBackgroundColor: '#f5f5f5',
-  borderRadius: '8px',
+  borderRadius: '22px',
   fontFamily: 'sans-serif',
   fontColor: '#000000',
   alignItems: 'center',
@@ -30,12 +30,20 @@ type AppearanceProviderProps = React.PropsWithChildren<SlashAuthStyle>;
 
 const AppearanceProvider = (props: AppearanceProviderProps) => {
   const ctxValue = useDeepEqualMemo(() => {
+    const theme = {
+      ...DEFAULT_MODAL_STYLES,
+      ...props.signInModalStyle,
+      testColor: 'red',
+    };
+
+    const root = document.documentElement;
+    Object.keys(theme).forEach((key) => {
+      root.style.setProperty(`--slashauth-${key}`, theme[key]);
+    });
+
     return {
       value: {
-        modalStyle: {
-          ...DEFAULT_MODAL_STYLES,
-          ...props.signInModalStyle,
-        },
+        modalStyle: theme,
       },
     };
   }, [props.signInModalStyle]);


### PR DESCRIPTION
## Refs

- **Issue**:  [SLA-1925](https://linear.app/slashauth/issue/SLA-1925/sr-singin-component-create-new-login-option-and-base-button-components)

## What?

Create button components for the redesign of the sign in drop-in component

## Screenshots: 

![image](https://user-images.githubusercontent.com/17853818/211439997-82e55f36-f2a8-4a90-ac17-e97fba3f92b5.png)

