### PR TITLE
SLA-1924 header components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0-beta.0",
+      "version": "1.0.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.0",
+  "version": "1.0.0-beta.1",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/sign-in/header.module.css
+++ b/src/core/ui/components/sign-in/header.module.css
@@ -1,0 +1,39 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 28px;
+  padding-top: 32px;
+  gap: 16px;
+  background-color: var(--slashauth-headerBackgroundColor, #F3F4F6);
+}
+
+.logo {
+  height: 24px;
+  width: auto;
+  margin: auto;
+}
+
+.logo img {
+  height: 100%;
+  width: auto;
+}
+
+.title {
+  display: block;
+  text-align: center;
+  font-weight: 500;
+  font-size: 24px;
+  line-height: 30px;
+  color: var(--slashauth-headerFontColor, #363849);
+  margin: 0;
+}
+
+.description {
+  display: block;
+  text-align: center;
+  font-weight: 500;
+  font-size: 16px;
+  line-height: 22px;
+  color: var(--slashauth-headerFontColor, #363849);
+  margin-top: 8px;
+}

--- a/src/core/ui/components/sign-in/header.tsx
+++ b/src/core/ui/components/sign-in/header.tsx
@@ -6,27 +6,35 @@ const Wrapper = ({ children }) => (
   <header className={styles.wrapper}>{children}</header>
 );
 
+Wrapper.displayName = 'Header.Wrapper';
+
 const Title = <C extends React.ElementType>({
-  as,
+  component,
   children,
 }: {
-  as?: C;
+  component?: C;
   children: React.ReactNode;
 }) => {
-  const Element = as ?? 'span';
+  const Element = component ?? 'span';
 
   return <Element className={styles.title}>{children}</Element>;
 };
 
+Title.displayName = 'Header.Title';
+
 const Description = ({ children }) => (
   <span className={styles.description}>{children}</span>
 );
+
+Description.displayName = 'Header.Description';
 
 const Logo = ({ url, alt }) => (
   <span className={styles.logo}>
     <img src={url} alt={alt} />
   </span>
 );
+
+Logo.displayName = 'Header.Logo';
 
 export const Header = ({
   title,
@@ -47,7 +55,7 @@ export const Header = ({
           <Description>{description}</Description>
         </h1>
       ) : (
-        <Title as="h1">{title}</Title>
+        <Title component="h1">{title}</Title>
       )}
     </Wrapper>
   );

--- a/src/core/ui/components/sign-in/header.tsx
+++ b/src/core/ui/components/sign-in/header.tsx
@@ -1,0 +1,54 @@
+import styles from './header.module.css';
+import { useAppearance } from '../../context/appearance';
+import React from 'react';
+
+const Wrapper = ({ children }) => (
+  <header className={styles.wrapper}>{children}</header>
+);
+
+const Title = <C extends React.ElementType>({
+  as,
+  children,
+}: {
+  as?: C;
+  children: React.ReactNode;
+}) => {
+  const Element = as ?? 'span';
+
+  return <Element className={styles.title}>{children}</Element>;
+};
+
+const Description = ({ children }) => (
+  <span className={styles.description}>{children}</span>
+);
+
+const Logo = ({ url, alt }) => (
+  <span className={styles.logo}>
+    <img src={url} alt={alt} />
+  </span>
+);
+
+export const Header = ({
+  title,
+  description,
+}: {
+  title: string;
+  description?: string;
+}) => {
+  const appearance = useAppearance();
+  const logoUrl = appearance.modalStyle.iconURL;
+
+  return (
+    <Wrapper>
+      <Logo url={logoUrl} alt="Company logo" />
+      {description ? (
+        <h1 style={{ margin: 0 }}>
+          <Title>{title}</Title>
+          <Description>{description}</Description>
+        </h1>
+      ) : (
+        <Title as="h1">{title}</Title>
+      )}
+    </Wrapper>
+  );
+};


### PR DESCRIPTION
## Refs

- **Issue**: [SLA-1924](https://linear.app/slashauth/issue/SLA-1924/sr-singin-component-create-new-header-component)

## What?

Create header component with the following props:
- title
- description

Logo is obtained from theme.

## Why?

Cuz its going to be a component widely used in the sign-in (actually every screen has a header).

## How?

Following a component composition approach

## Screenshots: 

![image](https://user-images.githubusercontent.com/17853818/211648252-3001a124-13d9-4ced-b4d8-f0f6f4e9cd70.png)
![image](https://user-images.githubusercontent.com/17853818/211648794-ac6fc407-c0e0-4710-88e0-263007ca5738.png)
![image](https://user-images.githubusercontent.com/17853818/211648924-7a22c907-164f-4672-bca9-8429fdfe01ea.png)
