### PR TITLE
SLA-1926 Create sign-in structure components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/primitives/text.module.css
+++ b/src/core/ui/components/primitives/text.module.css
@@ -1,0 +1,11 @@
+.text {
+  font-size: 14px;
+  color: var(--slashauth-fontColor, '#363849');
+  font-weight: 500;
+  line-height: '17px';
+  margin: 0;
+}
+
+.largeText {
+  font-size: 16px;
+}

--- a/src/core/ui/components/primitives/text.tsx
+++ b/src/core/ui/components/primitives/text.tsx
@@ -1,0 +1,30 @@
+import { classNames } from '../../../../shared/utils/classnames';
+import styles from './text.module.css';
+
+export enum Size {
+  Medium,
+  Large,
+}
+
+export const Text = ({
+  size = Size.Medium,
+  component,
+  children,
+}: {
+  size?: Size;
+  component?: React.ElementType;
+  children: React.ReactNode;
+}) => {
+  const Element = component ?? 'p';
+
+  return (
+    <Element
+      className={classNames(
+        styles.text,
+        size === Size.Large && styles.largeText
+      )}
+    >
+      {children}
+    </Element>
+  );
+};

--- a/src/core/ui/components/sign-in/layout/content.module.css
+++ b/src/core/ui/components/sign-in/layout/content.module.css
@@ -1,0 +1,10 @@
+
+.section {
+  flex: 1 1 auto;
+  /* TODO: SLA-1842 - add webkit scrollbar customized styles to display bar properly in windows devices */
+  overflow-y: scroll;
+}
+
+.section {
+  padding: 27px 34px 0 34px;
+}

--- a/src/core/ui/components/sign-in/layout/content.tsx
+++ b/src/core/ui/components/sign-in/layout/content.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './content.module.css';
+
+export const Section = ({ children }) => (
+  <section className={styles.section}>{children}</section>
+);
+
+Section.displayName = 'Content.Section';
+
+export const Content = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <div className={styles.content}>
+      <div>{children}</div>
+    </div>
+  );
+};

--- a/src/core/ui/components/sign-in/layout/footer.module.css
+++ b/src/core/ui/components/sign-in/layout/footer.module.css
@@ -1,0 +1,21 @@
+.footer {
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  padding: 28px;
+  flex: 0 1 auto;
+}
+
+.copyright {
+  font-size: 12px;
+  color: #B6BCC8;
+  font-weight: 500;
+}
+
+.logo {
+  font-weight: 700;
+  font-family: 'monospace';
+}

--- a/src/core/ui/components/sign-in/layout/footer.tsx
+++ b/src/core/ui/components/sign-in/layout/footer.tsx
@@ -1,0 +1,16 @@
+import styles from './footer.module.css';
+
+const Copyright = () => (
+  <small className={styles.copyright}>
+    Powered by <span className={styles.logo}>/auth</span>
+  </small>
+);
+
+Copyright.displayName = 'Footer.Copyright';
+
+export const Footer = ({ children }: { children?: React.ReactNode }) => (
+  <footer className={styles.footer}>
+    {children}
+    <Copyright />
+  </footer>
+);

--- a/src/core/ui/components/sign-in/layout/header.module.css
+++ b/src/core/ui/components/sign-in/layout/header.module.css
@@ -1,5 +1,6 @@
 .wrapper {
   display: flex;
+  flex: 0 1 auto;
   flex-direction: column;
   padding: 28px;
   padding-top: 32px;

--- a/src/core/ui/components/sign-in/layout/header.tsx
+++ b/src/core/ui/components/sign-in/layout/header.tsx
@@ -1,5 +1,5 @@
 import styles from './header.module.css';
-import { useAppearance } from '../../context/appearance';
+import { useAppearance } from '../../../context/appearance';
 import React from 'react';
 
 const Wrapper = ({ children }) => (


### PR DESCRIPTION
## Refs

- **Issue**: [SLA-1926](https://linear.app/slashauth/issue/SLA-1926/sr-singin-component-create-container-and-structure-components)
- **Bug Report**: N/A <!-- Sentry url -->

## What?

Create structure components to be able to create screens faster by reusing them:
- Content
- Footer

## Why?
- It will provide dev speed and reduce maintainability cost
- Will simplify code by using component composition

## Screenshots:

Example of screen using this components:
![image](https://user-images.githubusercontent.com/17853818/211882436-20d09bcf-7a5f-4073-a385-a57d8a60cd96.png)

