### PR TITLE
SLA-1931 Create successful sign-in screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0-beta.5",
+      "version": "1.0.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.6",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/sign-in/screens/success.module.css
+++ b/src/core/ui/components/sign-in/screens/success.module.css
@@ -1,3 +1,4 @@
+/* TODO: SLA-1968 - Create success icon class and component */
 .icon {
   background-color: #D7EFDC;
   color: #D7EFDC;

--- a/src/core/ui/components/sign-in/screens/success.module.css
+++ b/src/core/ui/components/sign-in/screens/success.module.css
@@ -1,0 +1,27 @@
+.icon {
+  background-color: #D7EFDC;
+  color: #D7EFDC;
+  border-radius: 50%;
+  margin: -0.6em 0;
+
+  width: 1.5em;
+  height: 1.5em;
+  transform: scale(0.8);
+
+  display: flex;
+  justify-content: center;
+  padding: 0.05em 0 0 0.05em;
+
+  font-weight: 900;
+
+  margin: -0.5em;
+}
+
+.icon:before {
+  content: "";
+  height: 0.3em;
+  width: 0.7em;
+  border-left: 0.15em solid #5DC073;
+  border-bottom: 0.15em solid #5DC073;
+  transform: translate3d(0, 0.4em, 0) rotate(-45deg);
+}

--- a/src/core/ui/components/sign-in/screens/success.tsx
+++ b/src/core/ui/components/sign-in/screens/success.tsx
@@ -15,6 +15,7 @@ export const SuccessScreen = () => {
       <Content>
         <Section>
           <Flex alignItems="center" justifyContent="center">
+            {/* TODO: SLA-1968 - Create a shared sign in process status component */}
             <HighlightedIcon>
               <img src={getIconsById('slashAuth')} alt="SlashAuth logo" />
             </HighlightedIcon>

--- a/src/core/ui/components/sign-in/screens/success.tsx
+++ b/src/core/ui/components/sign-in/screens/success.tsx
@@ -1,0 +1,34 @@
+import { Header } from '../layout/header';
+import { Content, Section } from '../layout/content';
+import { Footer } from '../layout/footer';
+import { useLoginMethods, getIconsById } from '../../../context/login-methods';
+import { Flex } from '../../primitives/container';
+import { HighlightedIcon } from '../../primitives/icon';
+import styles from './success.module.css';
+
+export const SuccessScreen = () => {
+  const { selectedLoginMethod } = useLoginMethods();
+
+  return (
+    <>
+      <Header title="You're logged in!" />
+      <Content>
+        <Section>
+          <Flex alignItems="center" justifyContent="center">
+            <HighlightedIcon>
+              <img src={getIconsById('slashAuth')} alt="SlashAuth logo" />
+            </HighlightedIcon>
+            <span className={styles.icon} />
+            <HighlightedIcon>
+              <img
+                src={getIconsById(selectedLoginMethod?.id)}
+                alt={`${selectedLoginMethod?.name} logo`}
+              />
+            </HighlightedIcon>
+          </Flex>
+        </Section>
+      </Content>
+      <Footer />
+    </>
+  );
+};


### PR DESCRIPTION
## Refs

- **Issue**:  resolves [SLA-1931](https://linear.app/slashauth/issue/SLA-1931/sr-singin-component-create-success-screen)

## What?

Create successful sign-in screen

## Why?

We need to provide feedback of the sign-in process to the users following the new sign-in designs.

## Screenshots:

<img width="595" alt="image (11)" src="https://user-images.githubusercontent.com/17853818/211965474-bb205d16-8293-4922-9c99-6c53e3635022.png">

