### PR TITLE
SLA-1845 Implement the new theming options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0-beta.6",
+      "version": "1.0.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.6",
+  "version": "1.0.0-beta.7",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/context/appearance.tsx
+++ b/src/core/ui/context/appearance.tsx
@@ -4,11 +4,16 @@ import { useDeepEqualMemo } from '../../../shared/hooks';
 import {
   ComputedSlashAuthModalStyle,
   SlashAuthStyle,
+  ThemeType,
 } from '../../../shared/types';
 import { createContextAndHook } from '../../../shared/utils';
-import { DARK_SLASHAUTH_ICON } from '../components/app-logo';
+import {
+  DARK_SLASHAUTH_ICON,
+  LIGHT_SLASHAUTH_ICON,
+} from '../components/app-logo';
 
 const DEFAULT_MODAL_STYLES: ComputedSlashAuthModalStyle = {
+  type: ThemeType.Light,
   backgroundColor: '#ffffff',
   buttonBackgroundColor: '#ffffff',
   hoverButtonBackgroundColor: '#f5f5f5',
@@ -17,6 +22,11 @@ const DEFAULT_MODAL_STYLES: ComputedSlashAuthModalStyle = {
   fontColor: '#000000',
   alignItems: 'center',
   iconURL: DARK_SLASHAUTH_ICON,
+  headerBackgroundColor: '#F3F4F6',
+  headerFontColor: '#363849',
+  lineColor: '#E5E7EB',
+  primaryButtonBackgroundColor: '#424559',
+  primaryButtonTextColor: 'white',
 };
 
 type AppearanceContextValue = {
@@ -33,8 +43,11 @@ const AppearanceProvider = (props: AppearanceProviderProps) => {
     const theme = {
       ...DEFAULT_MODAL_STYLES,
       ...props.signInModalStyle,
-      testColor: 'red',
     };
+
+    if (theme.type === ThemeType.Dark) {
+      theme.iconURL = LIGHT_SLASHAUTH_ICON;
+    }
 
     const root = document.documentElement;
     Object.keys(theme).forEach((key) => {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -7,6 +7,7 @@ export interface SlashAuthOptions {
 }
 
 export interface SlashAuthModalStyle {
+  type?: ThemeType;
   backgroundColor?: string;
   borderRadius?: string;
   alignItems?: string;
@@ -15,6 +16,11 @@ export interface SlashAuthModalStyle {
   buttonBackgroundColor?: string;
   hoverButtonBackgroundColor?: string;
   iconURL?: string;
+  headerBackgroundColor?: string;
+  headerFontColor?: string;
+  lineColor?: string;
+  primaryButtonBackgroundColor?: string;
+  primaryButtonTextColor?: string;
 }
 
 export interface SlashAuthLoginMethodConfig {
@@ -47,7 +53,12 @@ export interface SlashAuthLoginMethodConfig {
   };
 }
 
+export enum ThemeType {
+  Dark,
+  Light,
+}
 export interface ComputedSlashAuthModalStyle {
+  type: ThemeType;
   backgroundColor: string;
   borderRadius: string;
   alignItems: string;
@@ -56,6 +67,11 @@ export interface ComputedSlashAuthModalStyle {
   buttonBackgroundColor: string;
   hoverButtonBackgroundColor: string;
   iconURL: string;
+  headerBackgroundColor: string;
+  headerFontColor: string;
+  lineColor: string;
+  primaryButtonBackgroundColor: string;
+  primaryButtonTextColor: string;
 }
 
 export interface SlashAuthStyle {


### PR DESCRIPTION
## Refs

- **Issue**: resolves [SLA-1845](https://linear.app/slashauth/issue/SLA-1845/sr-theme-and-customization-of-login-component)

## What?

Implement the new theming options

## How?

4 things needed to be done:
- Change the default theme and update theme types (done in this PR)
- Update SlashAuth logo based on theme type (done in this PR)
- Pass theme attributes to component styles (previously it was done with react context and inline styles, once [this change](https://github.com/slashauth/slashauth-react/pull/54/files) was implemented it is done via native css properties)
- Use theme attributes inside all new components (done across the components PRs)

