### PR TITLE
SLA-1932 Create login failure page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0-beta.7",
+      "version": "1.0.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/primitives/margin.module.css
+++ b/src/core/ui/components/primitives/margin.module.css
@@ -5,3 +5,7 @@
 .top4 {
   margin-top: 1rem;
 }
+
+.top6 {
+  margin-top: 1.5rem;
+}

--- a/src/core/ui/components/sign-in/screens/action.tsx
+++ b/src/core/ui/components/sign-in/screens/action.tsx
@@ -46,7 +46,7 @@ export const ActionScreen = ({ navigateBack, signNonceAndLogin }) => {
             <strong>{shortenEthAddress(address)}</strong>
           </Text>
           <BaseButton
-            className={margin.top4}
+            className={margin.top6}
             primary
             wide
             onClick={signNonceAndLogin}

--- a/src/core/ui/components/sign-in/screens/failure.module.css
+++ b/src/core/ui/components/sign-in/screens/failure.module.css
@@ -1,0 +1,51 @@
+.icon {
+  background-color: #efd7d7;
+  color: #D7EFDC;
+  border-radius: 50%;
+  margin: -0.6em 0;
+
+  width: 1.5em;
+  height: 1.5em;
+  transform: scale(0.8);
+
+  display: flex;
+  justify-content: center;
+  padding: 0 0 0.05em 0.05em;
+
+  font-weight: 900;
+
+  margin: -0.5em;
+}
+
+.icon:before {
+  content: "";
+    height: 0.3em;
+    width: 0.8em;
+    border-bottom: 0.15em solid #c05d7e;
+    transform: translate3d(0.25em, 0.45em, 0) rotate(-45deg);
+}
+
+.icon:after {
+  content: "";
+  height: 0.3em;
+  width: 0.8em;
+  border-bottom: 0.15em solid #c05d7e;
+  transform: translate3d(-0.27em, 0.45em, 0) rotate(45deg); 
+}
+
+.verticalDivider {
+  border-top: 1px solid var(--slashauth-lineColor, #E5E7EB);
+  margin-top: 32px;
+  display: flex;
+  justify-content: center;
+}
+
+.support {
+  font-size: 12px;
+  color: #B6BCC8;
+  font-weight: 500;
+}
+
+.support a {
+  color: '#577EFD';
+}

--- a/src/core/ui/components/sign-in/screens/failure.module.css
+++ b/src/core/ui/components/sign-in/screens/failure.module.css
@@ -1,3 +1,4 @@
+/* TODO: SLA-1968 - Create cross icon class and component */
 .icon {
   background-color: #efd7d7;
   color: #D7EFDC;
@@ -33,6 +34,7 @@
   transform: translate3d(-0.27em, 0.45em, 0) rotate(45deg); 
 }
 
+/* TODO: SLA-1968 - Move this to a vertical divider css module */
 .verticalDivider {
   border-top: 1px solid var(--slashauth-lineColor, #E5E7EB);
   margin-top: 32px;
@@ -46,10 +48,12 @@
   font-weight: 500;
 }
 
+/* TODO: SLA-1968 - Move this to a links css module */
 .support a {
   color: #577EFD;
 }
 
+/* TODO: SLA-1968 - Move this to an errors css module */
 .errorMessage {
   color: #df1212;
 }

--- a/src/core/ui/components/sign-in/screens/failure.module.css
+++ b/src/core/ui/components/sign-in/screens/failure.module.css
@@ -47,5 +47,9 @@
 }
 
 .support a {
-  color: '#577EFD';
+  color: #577EFD;
+}
+
+.errorMessage {
+  color: #df1212;
 }

--- a/src/core/ui/components/sign-in/screens/failure.tsx
+++ b/src/core/ui/components/sign-in/screens/failure.tsx
@@ -1,0 +1,61 @@
+import { Header } from '../layout/header';
+import { Content, Section } from '../layout/content';
+import { Footer } from '../layout/footer';
+import { Text, Size } from '../../primitives/text';
+import { useLoginMethods, getIconsById } from '../../../context/login-methods';
+import { Flex } from '../../primitives/container';
+import { HighlightedIcon } from '../../primitives/icon';
+import { BaseButton } from '../../primitives/button';
+import { classNames } from '../../../../../shared/utils/classnames';
+import text from '../../primitives/text.module.css';
+import margin from '../../primitives/margin.module.css';
+import styles from './failure.module.css';
+
+export const FailureScreen = ({ retry }) => {
+  const { selectedLoginMethod } = useLoginMethods();
+
+  return (
+    <>
+      <Header title="Failed login attempt" />
+      <Content>
+        <Section>
+          <Flex alignItems="center" justifyContent="center">
+            <HighlightedIcon>
+              <img
+                style={{ width: 24 }}
+                src={getIconsById('slashAuth')}
+                alt="SlashAuth logo"
+              />
+            </HighlightedIcon>
+            <span className={styles.icon} />
+            <HighlightedIcon>
+              <img
+                src={getIconsById(selectedLoginMethod?.id)}
+                alt={`${selectedLoginMethod?.name} logo`}
+              />
+            </HighlightedIcon>
+          </Flex>
+          <Text
+            className={classNames(text.centered, margin.top4)}
+            size={Size.Large}
+          >
+            There was an error while trying to login.
+            <br />
+            <br />
+            <strong>Please try again</strong>
+          </Text>
+          <BaseButton className={margin.top4} primary wide onClick={retry}>
+            Retry
+          </BaseButton>
+        </Section>
+        <Section className={styles.verticalDivider}>
+          <small className={styles.support}>
+            If you continue to have issues, please contact us at{' '}
+            <a href="mailto:support@slashauth.com">support@slashauth.com</a>
+          </small>
+        </Section>
+      </Content>
+      <Footer />
+    </>
+  );
+};

--- a/src/core/ui/components/sign-in/screens/failure.tsx
+++ b/src/core/ui/components/sign-in/screens/failure.tsx
@@ -20,6 +20,7 @@ export const FailureScreen = ({ retry }) => {
       <Content>
         <Section>
           <Flex alignItems="center" justifyContent="center">
+            {/* TODO: SLA-1968 - Create a shared sign in process status component */}
             <HighlightedIcon>
               <img src={getIconsById('slashAuth')} alt="SlashAuth logo" />
             </HighlightedIcon>
@@ -31,10 +32,12 @@ export const FailureScreen = ({ retry }) => {
               />
             </HighlightedIcon>
           </Flex>
+          {/* TODO: SLA-1968 - Add centered property to text component */}
           <Text
             className={classNames(text.centered, margin.top4)}
             size={Size.Large}
           >
+            {/* TODO: SLA-1968 - Create a shared error message component */}
             <strong className={styles.errorMessage}>Please try again</strong>
             <br />
             <br />
@@ -44,9 +47,11 @@ export const FailureScreen = ({ retry }) => {
             Retry
           </BaseButton>
         </Section>
+        {/* TODO: SLA-1968 - Create a shared vertical divider component */}
         <Section className={styles.verticalDivider}>
           <small className={styles.support}>
             If you continue to have issues, please contact us at{' '}
+            {/* TODO: SLA-1968 - Create a shared link component */}
             <a href="mailto:support@slashauth.com">support@slashauth.com</a>
           </small>
         </Section>

--- a/src/core/ui/components/sign-in/screens/failure.tsx
+++ b/src/core/ui/components/sign-in/screens/failure.tsx
@@ -21,11 +21,7 @@ export const FailureScreen = ({ retry }) => {
         <Section>
           <Flex alignItems="center" justifyContent="center">
             <HighlightedIcon>
-              <img
-                style={{ width: 24 }}
-                src={getIconsById('slashAuth')}
-                alt="SlashAuth logo"
-              />
+              <img src={getIconsById('slashAuth')} alt="SlashAuth logo" />
             </HighlightedIcon>
             <span className={styles.icon} />
             <HighlightedIcon>
@@ -39,10 +35,10 @@ export const FailureScreen = ({ retry }) => {
             className={classNames(text.centered, margin.top4)}
             size={Size.Large}
           >
+            <strong className={styles.errorMessage}>Please try again</strong>
+            <br />
+            <br />
             There was an error while trying to login.
-            <br />
-            <br />
-            <strong>Please try again</strong>
           </Text>
           <BaseButton className={margin.top4} primary wide onClick={retry}>
             Retry

--- a/src/core/ui/components/sign-in/screens/failure.tsx
+++ b/src/core/ui/components/sign-in/screens/failure.tsx
@@ -34,16 +34,19 @@ export const FailureScreen = ({ retry }) => {
           </Flex>
           {/* TODO: SLA-1968 - Add centered property to text component */}
           <Text
-            className={classNames(text.centered, margin.top4)}
-            size={Size.Large}
+            className={classNames(
+              text.centered,
+              margin.top4,
+              styles.errorMessage
+            )}
           >
             {/* TODO: SLA-1968 - Create a shared error message component */}
-            <strong className={styles.errorMessage}>Please try again</strong>
-            <br />
-            <br />
+            Please try again
+          </Text>
+          <Text className={classNames(text.centered, margin.top2)}>
             There was an error while trying to login.
           </Text>
-          <BaseButton className={margin.top4} primary wide onClick={retry}>
+          <BaseButton className={margin.top6} primary wide onClick={retry}>
             Retry
           </BaseButton>
         </Section>


### PR DESCRIPTION
## Refs

- **Issue**: resolves [SLA-1932](https://linear.app/slashauth/issue/SLA-1932/sr-singin-component-create-error-screen)

## What?

Create login failure page

## Screenshots: 
<img width="612" alt="image" src="https://user-images.githubusercontent.com/17853818/212097308-5fc76235-6566-4137-85da-bc166fc053a4.png">

Before feedback was applied:
<img width="598" alt="image (12)" src="https://user-images.githubusercontent.com/17853818/211977924-52d20ec2-2d90-4a2f-b9ab-c39d94d6dec8.png">
