### PR TITLE
SLA-1846 Adapt drop-in to mobile screen size

### DIFF
--- a/src/core/ui/components/sign-in/layout/content.module.css
+++ b/src/core/ui/components/sign-in/layout/content.module.css
@@ -6,5 +6,12 @@
 }
 
 .section {
-  padding: 27px 34px 0 34px;
+  padding: 27px 16px 0 16px;
+}
+
+/*  Lateral padding is reduced in order to have more space available in mobile (and fit 2 columns in the sign in page) */
+@media screen and (min-width: 500px) {
+  .section {
+    padding: 27px 34px 0 34px;
+  }
 }

--- a/src/core/ui/components/sign-in/screens/sign-in.module.css
+++ b/src/core/ui/components/sign-in/screens/sign-in.module.css
@@ -1,8 +1,17 @@
 .loginOptions {
   margin: 8px 0;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(1, 1fr);
   gap: 8px;
+}
+
+/* 1 column layout until 2 can fit properly.
+Min-width is different from section's padding because from 464px to 500px
+we can fit 2 columns with reduced padding */
+@media screen and (min-width: 464px) {
+  .loginOptions {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .loginOptions > *:only-child {


### PR DESCRIPTION
## Refs

- **Issue**: [SLA-1846](https://linear.app/slashauth/issue/SLA-1846/sr-signin-drop-in-redesign-adapt-mobile)

## What?

Adapt drop-in to mobile screen size by making the two column layout 1 in small screens

## Why?

Because in smaller screens 2 columns do not fit

## Screenshots:

![image (15)](https://user-images.githubusercontent.com/17853818/212199320-be6d30e3-b182-4570-87ef-9ddf6bf425fb.png)
