### PR TITLE
Use container media queries to display proper layout in branding page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0-beta.9",
+      "version": "1.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/modal/modal-content.tsx
+++ b/src/core/ui/components/modal/modal-content.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { addFontFamily, isFamilySupported } from '../../fonts';
 import { IModalContainerStyles, ModalStyles } from '../../types/modal';
+import styles from './modal.module.css';
 
 type Props = {
   modalStyles: ModalStyles;
@@ -132,6 +133,7 @@ export const ModalContent = React.forwardRef<HTMLDivElement, Props>(
 
     return (
       <div
+        className={styles.modalContainer}
         style={wrapperStyles}
         ref={(node) => {
           modalRef.current = node;

--- a/src/core/ui/components/modal/modal.module.css
+++ b/src/core/ui/components/modal/modal.module.css
@@ -1,0 +1,4 @@
+.modalContainer {
+  container-type: inline-size;
+  container-name: modalContainer;
+}

--- a/src/core/ui/components/sign-in/layout/content.module.css
+++ b/src/core/ui/components/sign-in/layout/content.module.css
@@ -15,3 +15,9 @@
     padding: 27px 34px 0 34px;
   }
 }
+
+@container modalContainer (max-width: 499px) {
+  .section {
+    padding: 27px 16px 0 16px;
+  }
+}

--- a/src/core/ui/components/sign-in/screens/sign-in.module.css
+++ b/src/core/ui/components/sign-in/screens/sign-in.module.css
@@ -14,6 +14,12 @@ we can fit 2 columns with reduced padding */
   }
 }
 
+@container modalContainer (max-width: 463px) {
+  .loginOptions {
+    grid-template-columns: repeat(1, 1fr);
+  }
+}
+
 .loginOptions > *:only-child {
   grid-column: 1 / end;
 }


### PR DESCRIPTION
## What?

Use container media queries to display proper layout in branding page

## Why?

Because the wrapper in the branding page gets small and the layout did not adapt properly
<img width="720" alt="image" src="https://user-images.githubusercontent.com/17853818/212441441-e7401d71-f8f2-490e-9cc2-ff852b73015f.png">
<img width="640" alt="image" src="https://user-images.githubusercontent.com/17853818/212441453-91819a4f-0d73-4be4-9475-5952fe914a09.png">


## How?

Using the new container queries

## Screenshots:

<img width="1255" alt="image" src="https://user-images.githubusercontent.com/17853818/212441299-a299447d-3b1a-463b-b958-ae2827d71b31.png">
<img width="773" alt="image" src="https://user-images.githubusercontent.com/17853818/212441336-cac43e39-b745-4601-bd37-302b6e85ac50.png">
<img width="697" alt="image" src="https://user-images.githubusercontent.com/17853818/212441349-f99239ca-90e2-4b4c-bf65-ab2fda9b0182.png">
