### PR TITLE
SLA-1844 show link to open gmail if gmail.com domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ straightforward as possible.
 
 ### Fixed
 
+## [1.0.1] - 2023-01-20
+
+### Added
+
+- Show link to open gmail if gmail.com domain in the magic link flow
+
+### Fixed
+
+- Retry magic link
+
 ## [1.0.0] - 2023-01-20
 
 Redesign for the sign-in component.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/sign-in/magic-link-sign-in.tsx
+++ b/src/core/ui/components/sign-in/magic-link-sign-in.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Flow } from '../flow/flow';
 import { useCoreClient } from '../../context/slashauth-client';
 import { useRouter } from '../../router/context';
@@ -36,13 +36,32 @@ export const MagicLinkSignIn = () => {
     [client, connectAccounts, setProcessing, navigate, slashAuth]
   );
 
+  const isGmail = useMemo(
+    () => submittedEmail.includes('@gmail'),
+    [submittedEmail]
+  );
+
   return (
     <Flow.Part part="emailLink">
       {processing ? (
         <LoadingScreen
           description={`A link was sent to ${submittedEmail}`}
-          detailedDescription=""
+          detailedDescription={
+            isGmail ? (
+              <>
+                You can also{' '}
+                <a
+                  href="https://mail.google.com/mail/"
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  view the link here.
+                </a>
+              </>
+            ) : null
+          }
           navigateBack={async () => {
+            setProcessing(false);
             navigate('../');
           }}
         />

--- a/src/core/ui/components/sign-in/screens/loading.tsx
+++ b/src/core/ui/components/sign-in/screens/loading.tsx
@@ -23,7 +23,7 @@ export const LoadingScreen = ({
   navigateBack: ReactEventHandler;
   loading?: boolean;
   description: string;
-  detailedDescription: string;
+  detailedDescription: string | React.ReactNode;
 }) => {
   const { selectedLoginMethod } = useLoginMethods();
   const appearance = useAppearance();


### PR DESCRIPTION
## Refs

- **Issue**: [SLA-1844](https://linear.app/slashauth/issue/SLA-1844/sr-show-link-to-open-gmail-if-gmailcom-domain)

## What?

- Show link to open gmail if gmail.com domain
- Fix going retrying magic link

## Why?

After sending an email with magic link and going back to start the process again, the form did not appear. 

## Screenshots: 

<img width="574" alt="image" src="https://user-images.githubusercontent.com/17853818/213745691-5a5eedc1-3bf4-49a7-b9ed-b4861b062231.png">
<img width="593" alt="image" src="https://user-images.githubusercontent.com/17853818/213745722-07b34ebf-51df-4ec1-8b81-2881d5cfb9e1.png">
