### PR TITLE
Fix tsc types generation

### DIFF
--- a/src/core/ui/components/sign-in/layout/footer.tsx
+++ b/src/core/ui/components/sign-in/layout/footer.tsx
@@ -1,9 +1,8 @@
 import styles from './footer.module.css';
-import pkg from '../../../../../../package.json';
 
 const Copyright = () => (
   <a
-    href={pkg.homepage}
+    href="https://www.slashauth.com"
     target="_blank"
     rel="noreferrer"
     className={styles.copyright}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "outDir": "dist",
+    "rootDir": "src",
     "declaration": true,
     "emitDeclarationOnly": true,
     "downlevelIteration": true


### PR DESCRIPTION
Tsc is generating types inside the dist/src.
Projects using slashauth-react expect index.d.ts to be directly in dist and not in a subfolder.
This is caused by a module importing the package.json which is outside the project root directory (src).

To prevent this from happening again, the rootDir options is set in the tsconfig file. This will cause an error like the following: 
![image](https://user-images.githubusercontent.com/17853818/214108671-189563d1-53e4-4edc-bf57-afeffaa63827.png)
