### PR TITLE
SLA-2224 Enhance sign in mobile experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ straightforward as possible.
 
 ### Fixed
 
+## [2.1.1] - 2023-02-23
+
+### Fixed
+
+- Fixed sign-in modal user experience in mobile [#80](https://github.com/slashauth/slashauth-react/pull/80)
+
 ## [2.0.0] - 2023-02-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@slashauth/slashauth-react",
-      "version": "2.0.0",
+      "version": "2.1.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom-interactions": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@slashauth/slashauth-react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "homepage": "https://www.slashauth.xyz",
   "repository": {
     "type": "git",

--- a/src/core/ui/components/drop-down/icons/plusIcon.tsx
+++ b/src/core/ui/components/drop-down/icons/plusIcon.tsx
@@ -8,7 +8,7 @@ export const plusIcon = (
   >
     <path
       d="M7.99967 1.3335V14.6668M14.6663 8.00016L1.33301 8.00016"
-      stroke="#2F5FFC"
+      stroke="currentColor"
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"

--- a/src/core/ui/components/modal/modal-content.tsx
+++ b/src/core/ui/components/modal/modal-content.tsx
@@ -12,7 +12,10 @@ const MAX_HEIGHT_PX = 600;
 
 const baseModalContainerStyles = {
   maxWidth: '524px',
-  width: '100%',
+  width: 'calc(100% - 24px)',
+  maxHeight: 'calc(100% - 24px)',
+  display: 'flex',
+  flexDirection: 'column',
   transition: 'max-height 0.2s ease-in-out',
   WebkitTransition: 'max-height 0.2s ease-in-out',
   overflow: 'hidden',
@@ -107,7 +110,7 @@ export const ModalContent = React.forwardRef<HTMLDivElement, Props>(
     return (
       <div
         className={styles.modalContainer}
-        style={wrapperStyles}
+        style={wrapperStyles as React.CSSProperties}
         ref={(node) => {
           modalRef.current = node;
           if (typeof ref === 'function') {
@@ -122,7 +125,7 @@ export const ModalContent = React.forwardRef<HTMLDivElement, Props>(
           e.stopPropagation();
         }}
       >
-        <div>{children}</div>
+        {children}
       </div>
     );
   }

--- a/src/core/ui/components/primitives/button.module.css
+++ b/src/core/ui/components/primitives/button.module.css
@@ -11,7 +11,7 @@
   font-weight: 500;
 
   background: var(--slashauth-buttonBackgroundColor, #ffffff);
-  border: solid 1px var(--slashauth-lineColor, #E5E7EB);
+  border: 1px solid var(--slashauth-lineColor, #E5E7EB);
 
   cursor: pointer;
   transition: 0.3s;

--- a/src/core/ui/components/sign-in/layout/header.module.css
+++ b/src/core/ui/components/sign-in/layout/header.module.css
@@ -38,3 +38,12 @@
   color: var(--slashauth-headerFontColor, #363849);
   margin-top: 8px;
 }
+
+.closeButton {
+  all: unset;
+  position: absolute;
+  right: 24px;
+  top: 24px;
+  color: var(--slashauth-headerFontColor);
+  transform: rotate(45deg);
+}

--- a/src/core/ui/components/sign-in/layout/header.tsx
+++ b/src/core/ui/components/sign-in/layout/header.tsx
@@ -1,6 +1,8 @@
 import styles from './header.module.css';
 import { useAppearance } from '../../../context/appearance';
 import React from 'react';
+import { useCoreSlashAuth } from '../../../context/core-slashauth';
+import { plusIcon } from '../../drop-down/icons/plusIcon';
 
 const Wrapper = ({ children }) => (
   <header className={styles.wrapper}>{children}</header>
@@ -39,15 +41,26 @@ Logo.displayName = 'Header.Logo';
 export const Header = ({
   title,
   description,
+  closable,
 }: {
   title: string;
   description?: string;
+  closable?: boolean;
 }) => {
+  const slashauth = useCoreSlashAuth();
   const appearance = useAppearance();
   const logoUrl = appearance.modalStyle.iconURL;
 
   return (
     <Wrapper>
+      {closable ? (
+        <button
+          onClick={() => slashauth.closeSignIn()}
+          className={styles.closeButton}
+        >
+          {plusIcon}
+        </button>
+      ) : null}
       <Logo url={logoUrl} alt="Company logo" />
       {description ? (
         <h1 style={{ margin: 0 }}>

--- a/src/core/ui/components/sign-in/screens/sign-in.module.css
+++ b/src/core/ui/components/sign-in/screens/sign-in.module.css
@@ -5,6 +5,10 @@
   gap: 8px;
 }
 
+.scrollable {
+  border-bottom: 1px solid var(--slashauth-lineColor, #E5E7EB);
+}
+
 /* 1 column layout until 2 can fit properly.
 Min-width is different from section's padding because from 464px to 500px
 we can fit 2 columns with reduced padding */
@@ -12,9 +16,17 @@ we can fit 2 columns with reduced padding */
   .loginOptions {
     grid-template-columns: repeat(2, 1fr);
   }
+
+  .scrollable {
+    border-bottom: none;
+  }
 }
 
 @container modalContainer (max-width: 463px) {
+  .scrollable {
+    border-bottom: 1px solid var(--slashauth-lineColor, #E5E7EB);
+  }
+
   .loginOptions {
     grid-template-columns: repeat(1, 1fr);
   }

--- a/src/core/ui/components/sign-in/screens/sign-in.tsx
+++ b/src/core/ui/components/sign-in/screens/sign-in.tsx
@@ -46,8 +46,9 @@ export const SignInScreen = ({ startLoginWith }) => {
       <Header
         title="Welcome"
         description="Login by selecting an option below"
+        closable
       />
-      <Content>
+      <Content className={styles.scrollable}>
         {web3.length ? (
           <Section>
             <Text component="h2">Web3 Wallets</Text>


### PR DESCRIPTION
## Refs

- **Issue**: [SLA-2224](https://linear.app/slashauth/issue/SLA-2224/sign-in-component-mobile-design-enhancements)

## What?

Enhance sign in mobile experience by:
* Adding a 24px  padding to the sign in component in mobile devices
* Adding vertical scroll to the sign in methods when they dont fit in the screen, maintaining the header and footer always visible
* Adding a closing cross button at the top right corner of the modal

## Why?

In small mobile devices the user was not able to close the popup. Also when a lot of sign in methods were enabled, the header and footer elements which should always be visible were not displayed in the screen.

## Screenshots:

<img width="387" alt="image" src="https://user-images.githubusercontent.com/17853818/220968994-f71ebdbb-99fb-4681-a524-cfe3be675946.png">
<img width="377" alt="image" src="https://user-images.githubusercontent.com/17853818/220969219-193ba159-aed2-4f75-b94b-cf3ceacccd89.png">

<img width="916" alt="image" src="https://user-images.githubusercontent.com/17853818/220969091-7cae4c29-f1a1-453e-af5e-8f0cf424b2bb.png">
